### PR TITLE
Fix infinite recursion in CanEditChange()

### DIFF
--- a/Source/UnrealGT/Private/Generators/Text/GTActorInfoGeneratorComponent.cpp
+++ b/Source/UnrealGT/Private/Generators/Text/GTActorInfoGeneratorComponent.cpp
@@ -236,6 +236,8 @@ void UGTActorInfoGeneratorComponent::DrawDebug(FViewport* Viewport, FCanvas* Can
     Canvas->DrawItem(TextItem);
 }
 
+#if WITH_EDITOR
+
 bool UGTActorInfoGeneratorComponent::CanEditChange(const FProperty* InProperty) const
 {
     if (InProperty->GetFName() == GET_MEMBER_NAME_CHECKED(UGTActorInfoGeneratorComponent, bOnlyTrackOnScreenActors) || InProperty->GetFName() == GET_MEMBER_NAME_CHECKED(UGTActorInfoGeneratorComponent, bAccurateBoundingBoxes))
@@ -246,8 +248,10 @@ bool UGTActorInfoGeneratorComponent::CanEditChange(const FProperty* InProperty) 
         }
     }
     
-    return UGTActorInfoGeneratorComponent::CanEditChange(InProperty);
+    return Super::CanEditChange(InProperty);
 }
+
+#endif
 
 void UGTActorInfoGeneratorComponent::BeginPlay()
 {

--- a/Source/UnrealGT/Public/Generators/Text/GTActorInfoGeneratorComponent.h
+++ b/Source/UnrealGT/Public/Generators/Text/GTActorInfoGeneratorComponent.h
@@ -113,8 +113,8 @@ public:
 
     virtual void DrawDebug(FViewport* Viewport, FCanvas* Canvas) override;
 
-#ifdef WITH_EDITOR
-    virtual bool CanEditChange(const FProperty* InProperty) const;
+#if WITH_EDITOR
+    virtual bool CanEditChange(const FProperty* InProperty) const override;
 #endif
 
 protected:


### PR DESCRIPTION
This fix addresses issue #1, where the editor hangs when a GTActorInfoGenerator is used (at least that is what it does to me) under UE5.1. Note this fix does not address issues in the unrealgt directory of this repo, which appears to be a Win64 build of the plugin. I would suggest that dragonheat123 do that for consistency ( there are a lot of tools involved in building the plugin), or that we move the plugin build elsewhere. Also, this repo should be kept as similar to the original UnrealGT repo - where we hopefully can move this UE5.1 branch at some point. Just my 2 cents worth :).