### PR TITLE
Fix Issue #1 Skeletal mesh + wildcard bug.

### DIFF
--- a/Source/UnrealGT/Private/GTObjectFilter.cpp
+++ b/Source/UnrealGT/Private/GTObjectFilter.cpp
@@ -49,7 +49,7 @@ bool FGTObjectFilter::MatchesActor(AActor *Actor) const {
     if (SkeletalMesh || !WildcardMeshName.IsEmpty()) {
       USkeletalMeshComponent *SkeletalMeshComponent =
           Cast<USkeletalMeshComponent>(ActorComponent);
-      if (SkeletalMeshComponent) {
+      if (SkeletalMeshComponent && SkeletalMeshComponent->SkeletalMesh) {
         if (SkeletalMesh &&
             SkeletalMeshComponent->SkeletalMesh == SkeletalMesh) {
           bMatchesSkeletalMesh = true;


### PR DESCRIPTION
In UE5.1, a SkeletalMeshComponent can have a null SkeletalMesh member. Protect against this case.